### PR TITLE
Move from using found_posts to no_found_rows in WP_Query queries

### DIFF
--- a/classes/ppc_error_class.php
+++ b/classes/ppc_error_class.php
@@ -12,17 +12,17 @@
 
 //Time, in days, after which errors should be deleted
 define( 'PPC_ERROR_PURGE_TIME', 30 );
- 
+
 class PPC_Error {
-    
+
     private $wp_error;
-    
+
     /**
      * Handles an error.
-     * 
+     *
      * @since   2.21
      * @access  public
-     * 
+     *
      * @param   $code string Error code
      * @param   $message string Error message
      * @param   $data array (optional) Error data
@@ -30,31 +30,34 @@ class PPC_Error {
     */
     function __construct( $code, $message, $data = array(), $log = true ) {
         global $ppc_global_settings;
-        
+
         $error_details = array(
             'code' => $code,
             'message' => $message,
             'data' => $data,
             'time' => current_time( 'timestamp' )
         );
-        
+
         //If debug or logging enabled, make up detailed error (only shown if requested)
         if( PPC_DEBUG_SHOW OR ( PPC_DEBUG_LOG AND $log ) )
             $error_details['debug_message'] = 'An error was thrown with code "'.$code.'", message "'.$message.'" and debug data "'.var_export( $data, true ).'".';
-        
+
         if( PPC_DEBUG_SHOW )
             $error_details['output'] = $error_details['debug_message'];
         else
             $error_details['output'] = $error_details['message'];
-        
+
         //If logging enabled, push error with others
         if( PPC_DEBUG_LOG AND $log ) {
-            $errors = get_option( $ppc_global_settings['option_errors'], array() );
+            $errors = @file_get_contents( $ppc_global_settings['file_errors'] );
 
-            if( ! is_array( $errors ) OR empty( $errors ) ) $errors = array(); //for unknown reasons some users ended up with a string as errors option
-            
+            if( $errors !== false )
+				$errors = unserialize( $errors );
+			else
+				$errors = array();
+
             $errors[] = $error_details;
-            
+
 			//Get rid of old errors - only run once a day, ensure this through an option
 			$daily_delete = get_option( $ppc_global_settings['option_error_deletion'], true );
 			if( $daily_delete != false AND $daily_delete < current_time( 'timestamp' ) - 86400 ) {
@@ -66,23 +69,23 @@ class PPC_Error {
 				//See the record is not bigger than ~10MB
 				if( strlen( serialize( $errors ) ) > 10000 )
 					$errors = array( $error_details ); //only save latest error
-				
+
 				update_option( $ppc_global_settings['option_error_deletion'], current_time( 'timestamp' ) );
 			}
-			
-			if( update_option( $ppc_global_settings['option_errors'], $errors ) )
+
+			if( file_put_contents( $ppc_global_settings['file_errors'], serialize( $errors ) ) )
 				$this->wp_error = new WP_Error( 'ppc_update_error_update', 'Could not update errors option.', 'post-pay-counter' );
         }
-        
+
         $this->wp_error = new WP_Error( $error_details['code'], $error_details['output'], $data );
     }
-    
+
     /**
      * Returns the error stored in the class var.
-     * 
+     *
      * @since   2.21
      * @access  public
-     * 
+     *
      * @return  object WP_Error with current error details
      */
     function return_error() {
@@ -92,20 +95,23 @@ class PPC_Error {
 	/**
      * Retrieves an error from the error log, if found.
      * Several searching criteria available.
-     * 
+     *
      * @since   2.604
      * @access  public
      *
-     * @param	$args array 
+     * @param	$args array
      * @return  array|bool the error details, or bool false if not found
      */
     static function get_error( $args ) {
 		global $ppc_global_settings;
-		
-		if( isset( $args['error_code'] ) AND ! empty( $args['error_code'] ) ) {
-			$errors = get_option( $ppc_global_settings['option_errors'], array() );
 
-			if( ! is_array( $errors ) OR empty( $errors ) ) return false;
+		if( isset( $args['error_code'] ) AND ! empty( $args['error_code'] ) ) {
+			$errors = file_get_contents( $ppc_global_settings['file_errors'] );
+
+			if( $errors !== false )
+				$errors = unserialize( $errors );
+			else
+				return false;
 
 			$key = array_search( $args['error_code'], array_column( $errors, 'code' ) );
 

--- a/classes/ppc_general_functions_class.php
+++ b/classes/ppc_general_functions_class.php
@@ -246,7 +246,7 @@ class PPC_general_functions {
         );
         $first_available_post = new WP_Query( $args );
 
-		if( $first_available_post->found_posts == 0 )
+		if( $first_available_post->no_found_rows === false )
             $first_available_post_time = current_time( 'timestamp' );
         else
             $first_available_post_time = strtotime( $first_available_post->posts[0]->post_date );
@@ -262,7 +262,7 @@ class PPC_general_functions {
         );
         $last_available_post = new WP_Query( $args ); //for future scheduled posts
 
-		if( $last_available_post->found_posts !== 0 )
+		if( $last_available_post->no_found_rows === false )
 			$last_available_post_time = strtotime( $last_available_post->posts[0]->post_date );
 
 		if( ! isset( $last_available_post_time ) OR $last_available_post_time < current_time( 'timestamp' ) )

--- a/classes/ppc_generate_stats_class.php
+++ b/classes/ppc_generate_stats_class.php
@@ -129,7 +129,7 @@ class PPC_generate_stats {
 
 		do_action( 'ppc_got_requested_posts', $requested_posts );
 
-        if( $requested_posts->found_posts == 0 ) {
+        if( $requested_posts->no_found_rows === false ) {
             $error = new PPC_Error( 'ppc_empty_selection', __( 'Your query resulted in an empty result. Try to select a wider time range!' , 'post-pay-counter' ), self::$grp_args, false );
             return $error->return_error();
         }

--- a/classes/ppc_meta_boxes_class.php
+++ b/classes/ppc_meta_boxes_class.php
@@ -551,14 +551,15 @@ class PPC_meta_boxes {
         global $ppc_global_settings;
         $current_settings = $current_settings['args'];
 
-        $errors = get_option( $ppc_global_settings['option_errors'], array() );
+        $errors = file_get_contents( $ppc_global_settings['file_errors'] );
         ?>
 
         <p><?php printf( __( 'Errors which may happen during the plugin execution are logged and showed here. If something is not working properly, please send this list along with your support request. The log is cleared every now and then, but you can empty it manually with the button below. If you do not want errors to be logged at all, see the %1$sFAQ%2$s.', 'post-pay-counter' ), '<a href="http://wordpress.org/plugins/post-pay-counter/faq/" title="'.__( 'Frequently asked questions' ).'">', '</a>' ); ?></p>
         <textarea readonly="readonly" onclick="this.focus();this.select()" style="width: 100%; height: 150px;" name="ppc_error_log" title="<?php _e( 'To copy the error log, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'post-pay-counter' ); ?>"><?php
 
 
-        if( is_array( $errors) AND count( $errors ) > 0 ) {
+        if( $errors !== false ) {
+			$errors = unserialize( $errors );
             foreach( $errors as $error ) {
                 echo date_i18n( get_option( 'date_format' ), $error['time'] ).' '.date( 'H:i:s', $error['time'] )."\n";
                 echo $error['debug_message']."\n\n";

--- a/classes/ppc_update_class.php
+++ b/classes/ppc_update_class.php
@@ -168,6 +168,9 @@ class PPC_update_class {
 		//Insert default addons list
         PPC_addons::add_addons_list();
 
+        //Delete old errors wp_option, moved to a file
+        delete_option( $ppc_global_settings['option_errors'] );
+
         update_option( 'ppc_current_version', $ppc_global_settings['newest_version'] );
 
         //PRO gets deactivated as soon as PPC is deactivated - if it was active before, reactivate if now


### PR DESCRIPTION
This fixes #39, and most likely #37 as well.

It does look like sometimes the value of `found_posts` from a `WP_Query` is simply wrong, dunno why.